### PR TITLE
CNVS-465 - Analytics client API URL update

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,3 +1,3 @@
 module.exports = {
-  ANALYTICS_URL: 'https://axutefwx6k.execute-api.us-east-1.amazonaws.com/dev'
+  ANALYTICS_URL: 'https://canvas-analytics-api.bbcrewind.co.uk'
 };


### PR DESCRIPTION
Part of https://jira.dev.bbc.co.uk/browse/CNVS-465

- Pointing analytics client to new API URL